### PR TITLE
feat: add dependabot to keep go version up to date #10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- Enabling dependabot on the repo. So we can automate the PR's. 
- Just basic config to update go.mod and actions weekly.


About dependabot -> https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide