### PR TITLE
feat!: add Go generics support for unified App ID/Client ID authentication

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -11,7 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/google/go-github/v73/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"golang.org/x/oauth2"
 )
@@ -22,44 +23,135 @@ func TestNewApplicationTokenSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	type args struct {
-		appID      int64
-		privateKey []byte
-		opts       []ApplicationTokenOpt
-	}
 	tests := []struct {
-		name    string
-		args    args
-		want    oauth2.TokenSource
-		wantErr bool
+		name        string
+		constructor func() (oauth2.TokenSource, error)
+		wantErr     bool
 	}{
 		{
-			name:    "application id is not provided",
-			args:    args{},
-			wantErr: true,
-		},
-		{
-			name:    "private key is not provided",
-			args:    args{appID: 132},
-			wantErr: true,
-		},
-		{
-			name: "valid application token source",
-			args: args{
-				appID:      132,
-				privateKey: privateKey,
-				opts: []ApplicationTokenOpt{
-					WithApplicationTokenExpiration(15 * time.Minute),
-				},
+			name: "int64 application id is not provided",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource(int64(0), privateKey)
 			},
+			wantErr: true,
+		},
+		{
+			name: "string application id is not provided",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource("", privateKey)
+			},
+			wantErr: true,
+		},
+		{
+			name: "private key is not provided for int64",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource(int64(132), nil)
+			},
+			wantErr: true,
+		},
+		{
+			name: "private key is not provided for string",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource("Iv1.test", nil)
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid application token source with int64",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource(int64(132), privateKey, WithApplicationTokenExpiration(15*time.Minute))
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid application token source with string",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource("Iv1.1234567890abcdef", privateKey, WithApplicationTokenExpiration(15*time.Minute))
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewApplicationTokenSource(tt.args.appID, tt.args.privateKey, tt.args.opts...)
+			_, err := tt.constructor()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewApplicationTokenSource() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+		})
+	}
+}
+
+func TestApplicationTokenSource_TokenGeneration(t *testing.T) {
+	privateKey, err := generatePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		constructor func() (oauth2.TokenSource, error)
+		expectedIss string
+	}{
+		{
+			name: "numeric app id token generation",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource(int64(12345), privateKey)
+			},
+			expectedIss: "12345",
+		},
+		{
+			name: "client id token generation",
+			constructor: func() (oauth2.TokenSource, error) {
+				return NewApplicationTokenSource("Iv1.1234567890abcdef", privateKey)
+			},
+			expectedIss: "Iv1.1234567890abcdef",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenSource, err := tt.constructor()
+			if err != nil {
+				t.Fatalf("Failed to create token source: %v", err)
+			}
+
+			token, err := tokenSource.Token()
+			if err != nil {
+				t.Fatalf("Failed to generate token: %v", err)
+			}
+
+			// Verify token properties
+			if token.AccessToken == "" {
+				t.Error("Token access token is empty")
+			}
+			if token.TokenType != "Bearer" {
+				t.Errorf("Expected token type 'Bearer', got %s", token.TokenType)
+			}
+			if token.Expiry.IsZero() {
+				t.Error("Token expiry is not set")
+			}
+
+			// Parse and verify JWT claims
+			jwtToken, err := jwt.ParseWithClaims(token.AccessToken, &jwt.RegisteredClaims{}, func(token *jwt.Token) (interface{}, error) {
+				// For testing, we need to get the public key from the private key
+				privKey, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
+				if err != nil {
+					return nil, err
+				}
+				return &privKey.PublicKey, nil
+			})
+			if err != nil {
+				t.Fatalf("Failed to parse JWT token: %v", err)
+			}
+
+			claims, ok := jwtToken.Claims.(*jwt.RegisteredClaims)
+			if !ok {
+				t.Fatal("Failed to get JWT claims")
+			}
+
+			if claims.Issuer != tt.expectedIss {
+				t.Errorf("Expected issuer %s, got %s", tt.expectedIss, claims.Issuer)
 			}
 		})
 	}
@@ -104,7 +196,7 @@ func Test_installationTokenSource_Token(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	appSrc, err := NewApplicationTokenSource(34434, privateKey, WithApplicationTokenExpiration(5*time.Minute))
+	appSrc, err := NewApplicationTokenSource(int64(34434), privateKey, WithApplicationTokenExpiration(5*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,11 @@ go 1.24.6
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
-	github.com/google/go-github/v69 v69.2.0
+	github.com/google/go-github/v73 v73.0.0
 	golang.org/x/oauth2 v0.30.0
 )
 
 require (
-	github.com/google/go-github/v73 v73.0.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	golang.org/x/time v0.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArs
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
-github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
 github.com/google/go-github/v73 v73.0.0 h1:aR+Utnh+Y4mMkS+2qLQwcQ/cF9mOTpdwnzlaw//rG24=
 github.com/google/go-github/v73 v73.0.0/go.mod h1:fa6w8+/V+edSU0muqdhCVY7Beh1M8F1IlQPZIANKIYw=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=


### PR DESCRIPTION
- Introduce generic constraint Identifier interface supporting both int64 App IDs and string Client IDs in a single NewApplicationTokenSource function. This eliminates code duplication and provides type-safe authentication with automatic type inference.

- Enhanced documentation with official GitHub API references and JWT technical details while maintaining godoc compliance.

https://github.com/jferrl/go-githubauth/issues/14
