### PR TITLE
chore: Use ReuseTokenSource in NewApplicationTokenSource

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -61,6 +61,11 @@ func WithApplicationTokenExpiration(exp time.Duration) ApplicationTokenOpt {
 // Accepts either int64 App ID or string Client ID. GitHub recommends Client IDs for new apps.
 // Private key must be in PEM format. Generated JWTs are RS256-signed with iat, exp, and iss claims.
 // JWTs expire in max 10 minutes and include clock drift protection (iat set 60s in past).
+//
+// The returned token source is wrapped in oauth2.ReuseTokenSource to prevent unnecessary
+// token regeneration. Don't worry about wrapping the result again since ReuseTokenSource
+// prevents re-wrapping automatically.
+//
 // See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
 func NewApplicationTokenSource[T Identifier](id T, privateKey []byte, opts ...ApplicationTokenOpt) (oauth2.TokenSource, error) {
 	var issuer string
@@ -183,6 +188,11 @@ type installationTokenSource struct {
 
 // NewInstallationTokenSource creates a GitHub App installation token source.
 // Requires installation ID and a GitHub App JWT token source for authentication.
+//
+// The returned token source is wrapped in oauth2.ReuseTokenSource to prevent unnecessary
+// token regeneration. Don't worry about wrapping the result again since ReuseTokenSource
+// prevents re-wrapping automatically.
+//
 // See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token
 func NewInstallationTokenSource(id int64, src oauth2.TokenSource, opts ...InstallationTokenSourceOpt) oauth2.TokenSource {
 	ctx := context.Background()


### PR DESCRIPTION
Updated NewApplicationTokenSource to return an oauth2.ReuseTokenSource instead of the raw token source. This change improves token reuse and caching behavior.

## Description

Briefly describe the changes in this PR. What problem does it solve or what feature does it add?

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🎨 Code style/refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, tooling, etc.)

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md file
- [ ] I have added/updated code comments where necessary

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
- [ ] My changes are compatible with the supported Go versions (1.21+)

## Screenshots (if applicable)

If your changes include visual elements, please add screenshots here.

## Related Issues

Closes #(issue number)

## Additional Notes

Add any other context about the pull request here.
