### PR TITLE
chore: Retract v2.0.0 in go.mod due to versioning error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/jferrl/go-githubauth
 
 go 1.25
 
-// Retract v2.0.0 due to versioning error; use v1.x.x instead
-retract v2.0.0
+// Retract v2 due to versioning error; use v1.x.x instead
+retract v2
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/jferrl/go-githubauth
 
 go 1.25
 
+// Retract v2.0.0 due to versioning error; use v1.x.x instead
+retract v2.0.0
+
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-github/v73 v73.0.0


### PR DESCRIPTION

## Description

Added a retraction for v2.0.0 in go.mod with a comment explaining the versioning error. Users are directed to use v1.x.x instead.

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/refactoring (no functional changes)
- [ ] 🔧 Chore (dependency updates, tooling, etc.)

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Documentation

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md file
- [ ] I have added/updated code comments where necessary

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
- [ ] My changes are compatible with the supported Go versions (1.21+)

## Related Issues

#23 

