### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/jferrl/go-githubauth/security/code-scanning/1](https://github.com/jferrl/go-githubauth/security/code-scanning/1)

The best way to fix this issue is to explicitly set the `permissions` key near the top of the workflow file. Since the workflow only needs to read the repository contents for building (and does not need to write to contents, issues, packages, or any other GitHub entity), it should set `contents: read` as the minimal required permission. The safest and simplest fix is to add this top-level `permissions` block directly under the workflow's `name`, so it applies to all jobs. No change to imports or functionality is needed—just a single block addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
