### PR TITLE
docs: add godoc examples, package docs, llms.txt, and ghinstallation comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,48 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/jferrl/go-githubauth)](https://goreportcard.com/report/github.com/jferrl/go-githubauth)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 
-`go-githubauth` is a Go package that provides utilities for GitHub authentication, including generating and using GitHub App tokens, installation tokens, and personal access tokens.
+GitHub authentication for Go, exposed as standard [`oauth2.TokenSource`](https://pkg.go.dev/golang.org/x/oauth2#TokenSource) implementations: GitHub App JWTs, installation tokens, and personal access tokens. Depends only on `golang-jwt/jwt` and `golang.org/x/oauth2` — no GitHub SDK required.
 
-**v1.5.0** removes the `go-github` dependency, implementing a lightweight internal GitHub API client. This reduces external dependencies while maintaining full compatibility with the OAuth2 token source interface.
+## Installation
 
----
+```bash
+go get github.com/jferrl/go-githubauth
+```
 
-⭐ **Found this package useful?** Give it a star on GitHub! Your support helps others discover this project and motivates continued development.
+Requires Go 1.25+.
 
-[![Star this repo](https://img.shields.io/github/stars/jferrl/go-githubauth?style=social)](https://github.com/jferrl/go-githubauth/stargazers)
+## Quick start
 
-**Share this project:**
-[![Share on X](https://img.shields.io/badge/share%20on-X-1DA1F2?logo=x&style=flat-square)](https://twitter.com/intent/tweet?text=Check%20out%20go-githubauth%20-%20a%20Go%20package%20for%20GitHub%20App%20authentication%20with%20JWT%20and%20installation%20tokens!&url=https://github.com/jferrl/go-githubauth&hashtags=golang,github,authentication,jwt)
-[![Share on Reddit](https://img.shields.io/badge/share%20on-reddit-FF4500?logo=reddit&style=flat-square)](https://reddit.com/submit?url=https://github.com/jferrl/go-githubauth&title=go-githubauth:%20Go%20package%20for%20GitHub%20App%20authentication)
+Authenticating as a GitHub App is a two-step chain: an RS256 JWT identifies the App, and it is exchanged for an installation token scoped to one installation. Both sources cache their tokens and refresh them proactively.
 
----
+```go
+privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
+clientID := os.Getenv("GITHUB_APP_CLIENT_ID") // e.g. "Iv1.1234567890abcdef"
+installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
+
+appTokenSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
+if err != nil {
+	log.Fatal(err)
+}
+installationTokenSource := githubauth.NewInstallationTokenSource(installationID, appTokenSource)
+
+// Every request carries a valid installation token; refresh is automatic.
+// Works standalone or with any SDK that accepts an *http.Client, e.g.
+// github.NewClient(httpClient) from google/go-github.
+httpClient := oauth2.NewClient(context.Background(), installationTokenSource)
+```
+
+`NewApplicationTokenSource` accepts a string Client ID (recommended by GitHub) or an `int64` App ID (legacy) — the type is inferred from the argument. Runnable examples for every constructor live on [pkg.go.dev](https://pkg.go.dev/github.com/jferrl/go-githubauth).
+
+## Features
+
+- `oauth2.TokenSource` implementations for GitHub App JWTs, installation tokens, and personal access tokens (classic and fine-grained)
+- Token caching with **proactive refresh**: tokens regenerate 30s before expiry, eliminating in-flight 401s (tunable via `WithExpirySkew` / `WithInstallationExpirySkew`)
+- JWT signing through the standard `crypto.Signer` interface, so the private key can live in AWS KMS, GCP KMS, Azure Key Vault, Vault Transit, a PKCS#11 HSM, or ssh-agent
+- Webhook delivery verification (`X-Hub-Signature-256`, constant-time) with ready-made `http.Handler` middleware
+- GitHub Enterprise Server and GitHub Enterprise Cloud (data residency) support
+- Automatic single retry on throttled responses (`WithRetryOnThrottle`, enabled by default)
+- Two dependencies total: `golang-jwt/jwt` and `golang.org/x/oauth2`
 
 ## Comparison with ghinstallation
 
@@ -39,548 +66,82 @@
 
 If `ghinstallation` already fits your setup, there is no urgent reason to switch. Choose `go-githubauth` when you want oauth2-native composition, Client ID support, KMS-backed signing through the standard `crypto.Signer` interface, or a smaller dependency tree.
 
-## Features
-
-`go-githubauth` package provides implementations of the `TokenSource` interface from the `golang.org/x/oauth2` package. This interface has a single method, Token, which returns an *oauth2.Token.
-
-### v1.5.0 Features
-
-- **📦 Zero External Dependencies**: Removed `go-github` dependency - lightweight internal implementation
-- **🔐 Personal Access Token Support**: Native support for both classic and fine-grained personal access tokens
-- **⚡ Token Caching**: Dual-layer caching system for optimal performance
-  - JWT tokens cached until expiration (up to 10 minutes)  
-  - Installation tokens cached until expiration (defined by GitHub response)
-- **🚀 Pooled HTTP Client**: Production-ready HTTP client with connection pooling
-- **📈 Performance Optimizations**: Up to 99% reduction in unnecessary GitHub API calls
-- **🏗️ Production Ready**: Optimized for high-throughput and enterprise applications
-- **🌐 Simplified Enterprise Support**: Streamlined configuration with single base URL parameter
-
-### Core Capabilities
-
-- Generate GitHub Application JWT [Generating a jwt for a github app](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app)
-- Obtain GitHub App installation tokens [Authenticating as a GitHub App](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#authenticating-with-a-token-generated-by-an-app)
-- Authenticate with Personal Access Tokens (classic and fine-grained) [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
-- Verify incoming webhook deliveries with constant-time HMAC-SHA256 checks [Validating webhook deliveries](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries)
-- Sign JWTs with external `crypto.Signer` backends (AWS KMS, GCP KMS, Azure Key Vault, HashiCorp Vault Transit, PKCS#11 HSMs, ssh-agent) so the private key never touches process memory
-- RS256-signed JWTs with proper clock drift protection
-- Support for both legacy App IDs and modern Client IDs (recommended by GitHub)
-- Intelligent token caching with **proactive refresh** — tokens are regenerated 30s before expiry to eliminate in-flight 401s (tunable via `WithExpirySkew` / `WithInstallationExpirySkew`)
-- Clean HTTP clients with connection pooling and no shared state
-
-### Requirements
-
-- Go 1.25 or higher (required by `golang.org/x/oauth2`)
-- This package is designed to be used with the `golang.org/x/oauth2` package
-- No external GitHub SDK dependencies required
-
-## Installation
-
-To use `go-githubauth` in your project, you need to have Go installed. You can get the package via:
-
-```bash
-go get -u github.com/jferrl/go-githubauth
-```
-
-## Usage
-
-### Usage with [oauth2](golang.org/x/oauth2)
-
-You can use this package standalone with any HTTP client, or integrate it with the [go-github](https://github.com/google/go-github) SDK if you need additional GitHub API functionality.
-
-#### Client ID (Recommended)
+## Personal access tokens
 
 ```go
-package main
+tokenSource := githubauth.NewPersonalAccessTokenSource(os.Getenv("GITHUB_TOKEN"))
+httpClient := oauth2.NewClient(context.Background(), tokenSource)
+```
 
-import (
- "context"
- "fmt"
- "os"
- "strconv"
+Works with both classic (`ghp_...`) and fine-grained (`github_pat_...`) tokens.
 
- "github.com/google/go-github/v76/github"
- "github.com/jferrl/go-githubauth"
- "golang.org/x/oauth2"
+## GitHub Enterprise
+
+- `WithEnterpriseURL` — GitHub Enterprise Server (GHES). The URL is normalized the way GHES expects, appending `/api/v3/` when needed.
+- `WithBaseURL` — the URL is used verbatim. Fits GitHub Enterprise Cloud with data residency (`https://api.SUBDOMAIN.ghe.com/`) or an `httptest` server in tests.
+
+```go
+githubauth.NewInstallationTokenSource(installationID, appTokenSource,
+	githubauth.WithEnterpriseURL("https://github.example.com"))
+
+githubauth.NewInstallationTokenSource(installationID, appTokenSource,
+	githubauth.WithBaseURL("https://api.octocorp.ghe.com"))
+```
+
+Options combine in any order. An unparseable URL (or a nil client passed to `WithHTTPClient`) is reported by the first `Token()` call instead of silently falling back to the public GitHub API.
+
+## Proactive token refresh
+
+`oauth2.ReuseTokenSource` refreshes a cached token only *after* it expires, so a request that starts just before expiry can reach GitHub with a dead credential and 401. Both constructors instead wrap their sources in `ReuseTokenSourceWithSkew`, refreshing when `time.Until(exp) <= skew` (default `DefaultExpirySkew`, 30s).
+
+```go
+appTokenSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey,
+	githubauth.WithApplicationTokenExpiration(1*time.Minute),
+	githubauth.WithExpirySkew(5*time.Second), // effective validity: 55s
 )
+```
 
-func main() {
- privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
- clientID := os.Getenv("GITHUB_APP_CLIENT_ID") // e.g., "Iv1.1234567890abcdef"
- installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
+A zero or negative skew restores exact `oauth2.ReuseTokenSource` behavior. The wrapper is exported as `ReuseTokenSourceWithSkew` for use with any third-party `oauth2.TokenSource`, and is safe for concurrent use.
 
- // Go automatically infers the type as string for Client ID
- appTokenSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
- if err != nil {
-  fmt.Println("Error creating application token source:", err)
-  return
- }
+## Signing with external key stores (KMS, HSM, Vault)
 
- installationTokenSource := githubauth.NewInstallationTokenSource(installationID, appTokenSource)
+`NewApplicationTokenSourceFromSigner` accepts any RSA-backed [`crypto.Signer`](https://pkg.go.dev/crypto#Signer), so the App private key never touches process memory. GitHub requires RS256; non-RSA signers are rejected at construction time.
 
- // oauth2.NewClient creates a new http.Client that adds an Authorization header with the token
- httpClient := oauth2.NewClient(context.Background(), installationTokenSource)
- githubClient := github.NewClient(httpClient)
+```go
+// signer: *rsa.PrivateKey, or a wrapper for AWS KMS, GCP KMS, Azure Key
+// Vault, Vault Transit, a PKCS#11 HSM, or ssh-agent.
+appTokenSource, err := githubauth.NewApplicationTokenSourceFromSigner(clientID, signer)
+```
 
- _, _, err = githubClient.PullRequests.CreateComment(context.Background(), "owner", "repo", 1, &github.PullRequestComment{
-  Body: github.String("Awesome comment!"),
- })
- if err != nil {
-  fmt.Println("Error creating comment:", err)
-  return
- }
+All major backends support the required `RSASSA_PKCS1_V1_5_SHA_256` operation: [AWS KMS](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html), [GCP KMS](https://cloud.google.com/kms/docs/create-validate-signatures), [Azure Key Vault](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/sign), [Vault Transit](https://developer.hashicorp.com/vault/api-docs/secret/transit#sign-data), and [PKCS#11 via crypto11](https://github.com/ThalesGroup/crypto11). Community `crypto.Signer` adapters: [form3tech-oss/jwt-go-aws-kms](https://github.com/form3tech-oss/jwt-go-aws-kms), [salrashid123/signer](https://github.com/salrashid123/signer).
+
+## Webhook verification
+
+The `webhook` subpackage verifies the `X-Hub-Signature-256` header (HMAC-SHA256, constant time) and ships middleware that restores the body for downstream handlers. Failed verifications short-circuit with 401; oversized bodies return 413.
+
+```go
+secret := []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))
+
+mux := http.NewServeMux()
+mux.HandleFunc("/webhook", handleWebhook) // body is already authenticated here
+
+log.Fatal(http.ListenAndServe(":8080", webhook.Middleware(secret)(mux)))
+```
+
+Options: `webhook.WithMaxPayloadSize(n)` (default 25 MiB, GitHub's delivery cap) and `webhook.WithErrorHandler(fn)`.
+
+Outside `net/http` (Lambda, queues), use `webhook.Verify` directly:
+
+```go
+if err := webhook.Verify(secret, body, signature); err != nil {
+	// branch with errors.Is: webhook.ErrMissingSignature,
+	// webhook.ErrInvalidSignatureFormat, webhook.ErrSignatureMismatch
 }
 ```
-
-#### App ID (Legacy)
-
-```go
-package main
-
-import (
- "context"
- "fmt"
- "os"
- "strconv"
-
- "github.com/google/go-github/v76/github"
- "github.com/jferrl/go-githubauth"
- "golang.org/x/oauth2"
-)
-
-func main() {
- privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
- appID, _ := strconv.ParseInt(os.Getenv("GITHUB_APP_ID"), 10, 64)
- installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
-
- // Explicitly cast to int64 for App ID - Go automatically infers the type
- appTokenSource, err := githubauth.NewApplicationTokenSource(int64(appID), privateKey)
- if err != nil {
-  fmt.Println("Error creating application token source:", err)
-  return
- }
-
- installationTokenSource := githubauth.NewInstallationTokenSource(installationID, appTokenSource)
-
- httpClient := oauth2.NewClient(context.Background(), installationTokenSource)
- githubClient := github.NewClient(httpClient)
-
- _, _, err = githubClient.PullRequests.CreateComment(context.Background(), "owner", "repo", 1, &github.PullRequestComment{
-  Body: github.String("Awesome comment!"),
- })
- if err != nil {
-  fmt.Println("Error creating comment:", err)
-  return
- }
-}
-```
-
-### Generate GitHub Application Token
-
-First, create a GitHub App and generate a private key. To authenticate as a GitHub App, you need to generate a JWT. [Generating a JWT for a GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app)
-
-#### With Client ID (Recommended)
-
-```go
-package main
-
-import (
- "fmt"
- "os"
- "time"
-
- "github.com/jferrl/go-githubauth"
-)
-
-func main() {
- privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
- clientID := os.Getenv("GITHUB_APP_CLIENT_ID") // e.g., "Iv1.1234567890abcdef"
-
- // Type automatically inferred as string
- tokenSource, err := githubauth.NewApplicationTokenSource(
-  clientID, 
-  privateKey, 
-  githubauth.WithApplicationTokenExpiration(5*time.Minute),
- )
- if err != nil {
-  fmt.Println("Error creating token source:", err)
-  return
- }
-
- token, err := tokenSource.Token()
- if err != nil {
-  fmt.Println("Error generating token:", err)
-  return
- }
-
- fmt.Println("Generated JWT token:", token.AccessToken)
-}
-```
-
-#### With App ID
-
-```go
-package main
-
-import (
- "fmt"
- "os"
- "strconv"
- "time"
-
- "github.com/jferrl/go-githubauth"
-)
-
-func main() {
- privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
- appID, _ := strconv.ParseInt(os.Getenv("GITHUB_APP_ID"), 10, 64)
-
- // Type automatically inferred as int64
- tokenSource, err := githubauth.NewApplicationTokenSource(
-  int64(appID), 
-  privateKey, 
-  githubauth.WithApplicationTokenExpiration(5*time.Minute),
- )
- if err != nil {
-  fmt.Println("Error creating token source:", err)
-  return
- }
-
- token, err := tokenSource.Token()
- if err != nil {
-  fmt.Println("Error generating token:", err)
-  return
- }
-
- fmt.Println("Generated JWT token:", token.AccessToken)
-}
-```
-
-### Generate GitHub App Installation Token
-
-To authenticate as a GitHub App installation, you need to obtain an installation token using your GitHub App JWT.
-
-```go
-package main
-
-import (
- "fmt"
- "os"
- "strconv"
-
- "github.com/jferrl/go-githubauth"
-)
-
-func main() {
- privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
- clientID := os.Getenv("GITHUB_APP_CLIENT_ID") // e.g., "Iv1.1234567890abcdef"
- installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
-
- // Create GitHub App JWT token source with Client ID
- appTokenSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
- if err != nil {
-  fmt.Println("Error creating application token source:", err)
-  return
- }
-
- // Create installation token source using the app token source
- installationTokenSource := githubauth.NewInstallationTokenSource(installationID, appTokenSource)
-
- token, err := installationTokenSource.Token()
- if err != nil {
-  fmt.Println("Error generating installation token:", err)
-  return
- }
-
- fmt.Println("Generated installation token:", token.AccessToken)
-}
-```
-
-### GitHub Enterprise and Custom Base URLs
-
-The installation token source talks to `https://api.github.com/` by default. Two options point it elsewhere:
-
-- `WithEnterpriseURL` — for **GitHub Enterprise Server (GHES)**. The supplied URL is normalized the way GHES expects, appending `/api/v3/` when the host is not already an `api.` subdomain.
-- `WithBaseURL` — uses the URL **verbatim** (only adding a trailing slash when missing), closely mirroring how `go-github` lets you set a custom endpoint. No `/api/v3/` suffix is added. Use it for **GitHub Enterprise Cloud (GHEC) with data residency** (`https://api.SUBDOMAIN.ghe.com/`) or to point the client at an `httptest` server in your tests.
-
-```go
-// GitHub Enterprise Server (GHES)
-installationTokenSource := githubauth.NewInstallationTokenSource(
-    installationID,
-    appTokenSource,
-    githubauth.WithEnterpriseURL("https://github.example.com"),
-)
-
-// GitHub Enterprise Cloud (GHEC) with data residency
-installationTokenSource = githubauth.NewInstallationTokenSource(
-    installationID,
-    appTokenSource,
-    githubauth.WithBaseURL("https://api.octocorp.ghe.com"),
-)
-
-// Point at an httptest server in tests
-installationTokenSource = githubauth.NewInstallationTokenSource(
-    installationID,
-    appTokenSource,
-    githubauth.WithBaseURL(server.URL),
-)
-```
-
-Option order does not matter — `WithBaseURL`, `WithEnterpriseURL`, `WithHTTPClient`, and `WithRetryOnThrottle` can be combined in any order. If the provided URL cannot be parsed (or a `nil` HTTP client is passed), the misconfiguration is reported by the first call to `Token()` rather than silently falling back to the public GitHub API.
-
-### Proactive Token Refresh
-
-`oauth2.ReuseTokenSource` only refreshes a cached token *after* its expiry has passed. A request that starts at `T-100ms` with a token expiring at `T` can arrive at GitHub with an already-expired credential and receive a 401 that the caller must manually retry. This is especially painful with short application-token windows (default 10 min, optionally lower).
-
-Both `NewApplicationTokenSource` and `NewInstallationTokenSource` wrap the returned source in `ReuseTokenSourceWithSkew`, which refreshes when `time.Until(exp) <= skew`. The default `DefaultExpirySkew` is **30 seconds**, so a default 10-minute application JWT has ~9m30s of effective validity — the tail risk is closed, the overhead is negligible.
-
-```go
-// Use a shorter skew (e.g. to maximize validity for very short JWTs).
-appTokenSource, err := githubauth.NewApplicationTokenSource(
-    clientID,
-    privateKey,
-    githubauth.WithApplicationTokenExpiration(1*time.Minute),
-    githubauth.WithExpirySkew(5*time.Second),
-)
-
-// Override the installation-layer skew too (default 30s is usually fine for 1h tokens).
-installationTokenSource := githubauth.NewInstallationTokenSource(
-    installationID,
-    appTokenSource,
-    githubauth.WithInstallationExpirySkew(1*time.Minute),
-)
-```
-
-Passing `WithExpirySkew(0)` (or any non-positive value) disables the skew and falls back to the exact `oauth2.ReuseTokenSource` behavior. For third-party `oauth2.TokenSource` implementations outside this package, `ReuseTokenSourceWithSkew` is exported directly:
-
-```go
-src := githubauth.ReuseTokenSourceWithSkew(nil, someTokenSource, 30*time.Second)
-```
-
-The wrapper is safe for concurrent use — concurrent `Token()` calls that find the cache stale collapse into a single upstream fetch.
-
-### Signing with External Key Stores (AWS KMS, GCP KMS, Vault, HSM)
-
-For regulated or high-security environments, the private key should never leave its secure boundary. `NewApplicationTokenSourceFromSigner` accepts any `crypto.Signer` whose public key is RSA — AWS KMS, Google Cloud KMS, Azure Key Vault, HashiCorp Vault Transit, PKCS#11 HSMs, and ssh-agent all fit.
-
-The same `crypto.Signer` call (`Sign(rand, digest, crypto.SHA256)`) maps to each backend's native RSASSA-PKCS1-v1_5 SHA-256 signing operation. GitHub requires RS256.
-
-```go
-package main
-
-import (
- "context"
- "fmt"
- "os"
-
- "github.com/jferrl/go-githubauth"
-)
-
-func main() {
- clientID := os.Getenv("GITHUB_APP_CLIENT_ID")
-
- // signer is any crypto.Signer backed by an RSA key: *rsa.PrivateKey,
- // an AWS KMS wrapper, a GCP KMS wrapper, a Vault Transit wrapper,
- // a PKCS#11 HSM library like github.com/ThalesGroup/crypto11, or
- // an ssh-agent adapter. The private key never touches process memory.
- signer := newKMSBackedSigner(context.Background(), os.Getenv("KMS_KEY_ARN"))
-
- appTokenSource, err := githubauth.NewApplicationTokenSourceFromSigner(clientID, signer)
- if err != nil {
-  fmt.Println("Error creating application token source:", err)
-  return
- }
-
- token, err := appTokenSource.Token()
- if err != nil {
-  fmt.Println("Error generating JWT:", err)
-  return
- }
-
- fmt.Println("Generated JWT token:", token.AccessToken)
-}
-```
-
-Backend references (all support `RSASSA_PKCS1_V1_5_SHA_256` on RSA keys ≥ 2048):
-
-- **AWS KMS** — [Sign API](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html), [`service/kms`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/kms). Community adapters: [form3tech-oss/jwt-go-aws-kms](https://github.com/form3tech-oss/jwt-go-aws-kms), [salrashid123/signer](https://github.com/salrashid123/signer)
-- **Google Cloud KMS** — [Create and validate signatures](https://cloud.google.com/kms/docs/create-validate-signatures), [`cloud.google.com/go/kms/apiv1`](https://pkg.go.dev/cloud.google.com/go/kms/apiv1). Adapter: [salrashid123/signer/kms](https://github.com/salrashid123/signer/tree/master/kms)
-- **HashiCorp Vault Transit** — [Sign data](https://developer.hashicorp.com/vault/api-docs/secret/transit#sign-data). Adapter: [salrashid123/signer/vault](https://github.com/salrashid123/signer/tree/master/vault)
-- **Azure Key Vault** — [Sign API](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/sign) with `alg=RS256`
-- **PKCS#11 / HSM** — [ThalesGroup/crypto11](https://github.com/ThalesGroup/crypto11) implements `crypto.Signer` directly, no adapter needed
-
-**🔐 Security Note**: The signer's public key must be RSA. The constructor rejects non-RSA signers (ECDSA, ed25519) at construction time since GitHub requires RS256.
-
-### Personal Access Token Authentication
-
-GitHub Personal Access Tokens provide direct authentication for users and organizations. This package supports both classic personal access tokens and fine-grained personal access tokens.
-
-#### Using Personal Access Tokens
-
-##### With oauth2 Client (Standalone)
-
-```go
-package main
-
-import (
- "context"
- "fmt"
- "io"
- "net/http"
- "os"
-
- "github.com/jferrl/go-githubauth"
- "golang.org/x/oauth2"
-)
-
-func main() {
- // Personal access token from environment variable
- token := os.Getenv("GITHUB_TOKEN") // e.g., "ghp_..." or "github_pat_..."
-
- // Create token source
- tokenSource := githubauth.NewPersonalAccessTokenSource(token)
-
- // Create HTTP client with OAuth2 transport
- httpClient := oauth2.NewClient(context.Background(), tokenSource)
-
- // Use the HTTP client for GitHub API calls
- resp, err := httpClient.Get("https://api.github.com/user")
- if err != nil {
-  fmt.Println("Error getting user:", err)
-  return
- }
- defer resp.Body.Close()
-
- body, _ := io.ReadAll(resp.Body)
- fmt.Printf("User info: %s\n", body)
-}
-```
-
-##### With go-github SDK (Optional)
-
-```go
-package main
-
-import (
- "context"
- "fmt"
- "os"
-
- "github.com/google/go-github/v76/github"
- "github.com/jferrl/go-githubauth"
- "golang.org/x/oauth2"
-)
-
-func main() {
- // Personal access token from environment variable
- token := os.Getenv("GITHUB_TOKEN") // e.g., "ghp_..." or "github_pat_..."
-
- // Create token source
- tokenSource := githubauth.NewPersonalAccessTokenSource(token)
-
- // Create HTTP client with OAuth2 transport
- httpClient := oauth2.NewClient(context.Background(), tokenSource)
- githubClient := github.NewClient(httpClient)
-
- // Use the GitHub client for API calls
- user, _, err := githubClient.Users.Get(context.Background(), "")
- if err != nil {
-  fmt.Println("Error getting user:", err)
-  return
- }
-
- fmt.Printf("Authenticated as: %s\n", user.GetLogin())
-}
-```
-
-#### Creating Personal Access Tokens
-
-1. **Classic Personal Access Token**: Visit [GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)](https://github.com/settings/tokens)
-2. **Fine-grained Personal Access Token**: Visit [GitHub Settings > Developer settings > Personal access tokens > Fine-grained tokens](https://github.com/settings/personal-access-tokens/new)
-
-**🔐 Security Note**: Store your personal access tokens securely and never commit them to version control. Use environment variables or secure credential management systems.
-
-### Webhook Signature Verification
-
-GitHub signs every webhook delivery with HMAC-SHA256 over the raw request body, using the secret configured on the webhook. The `webhook` subpackage verifies the `X-Hub-Signature-256` header in constant time and ships an `http.Handler` middleware that restores the body for downstream handlers.
-
-See [Validating webhook deliveries](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries).
-
-#### With the middleware (recommended)
-
-```go
-package main
-
-import (
- "encoding/json"
- "log"
- "net/http"
- "os"
-
- "github.com/jferrl/go-githubauth/webhook"
-)
-
-func main() {
- secret := []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))
-
- mux := http.NewServeMux()
- mux.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
-  event := r.Header.Get(webhook.EventHeader)
-  delivery := r.Header.Get(webhook.DeliveryHeader)
-
-  var payload map[string]any
-  if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-   http.Error(w, "bad payload", http.StatusBadRequest)
-   return
-  }
-
-  log.Printf("received %s delivery=%s", event, delivery)
-  w.WriteHeader(http.StatusNoContent)
- })
-
- // Middleware verifies the signature, restores r.Body, then invokes mux.
- // Failed verifications short-circuit with 401; oversized bodies return 413.
- log.Fatal(http.ListenAndServe(":8080", webhook.Middleware(secret)(mux)))
-}
-```
-
-Middleware options:
-
-- `webhook.WithMaxPayloadSize(n int64)` — override the 25 MiB default cap (GitHub's documented delivery limit).
-- `webhook.WithErrorHandler(fn)` — customize the response for verification failures (e.g., structured logging, alternate status codes).
-
-#### Direct verification (queues, Lambda, custom transports)
-
-Use `webhook.Verify` when the request does not arrive through `net/http`, for example in AWS Lambda, Cloud Run event triggers, or after consuming from a message queue.
-
-```go
-import (
- "errors"
-
- "github.com/jferrl/go-githubauth/webhook"
-)
-
-func handle(secret, body []byte, signature string) error {
- if err := webhook.Verify(secret, body, signature); err != nil {
-  switch {
-  case errors.Is(err, webhook.ErrMissingSignature):
-   // header absent
-  case errors.Is(err, webhook.ErrInvalidSignatureFormat):
-   // malformed header
-  case errors.Is(err, webhook.ErrSignatureMismatch):
-   // wrong secret or tampered body
-  }
-  return err
- }
- // body is trusted from here
- return nil
-}
-```
-
-**🔐 Security Note**: Store the webhook secret with the same care as a credential. A leaked secret lets an attacker forge deliveries to your endpoint.
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request on GitHub.
+Contributions are welcome! Please open an issue or submit a pull request on GitHub. If this package is useful to you, [a star](https://github.com/jferrl/go-githubauth/stargazers) helps others discover it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@
 
 ---
 
+## Comparison with ghinstallation
+
+[`ghinstallation`](https://github.com/bradleyfalzon/ghinstallation) is the long-standing library in this space and works well. The core difference is the integration model: `ghinstallation` is an `http.RoundTripper` you install as an HTTP transport, while `go-githubauth` implements `oauth2.TokenSource`, so credentials compose with anything that speaks oauth2 — `oauth2.NewClient`, [go-github](https://github.com/google/go-github), gRPC per-RPC credentials, or code that just needs the token string.
+
+|  | go-githubauth | ghinstallation |
+|---|---|---|
+| Integration model | `oauth2.TokenSource` | `http.RoundTripper` |
+| Dependencies | `golang-jwt/jwt`, `x/oauth2` | `golang-jwt/jwt`, `google/go-github` |
+| App identifiers | Client ID (`string`, recommended by GitHub) and App ID (`int64`) | App ID (`int64`) |
+| Token refresh | Proactive, tunable (`WithExpirySkew`, default 30s) | Proactive, fixed 1 minute |
+| External signers (KMS/HSM) | Standard `crypto.Signer` — existing KMS adapters plug in directly | Library-specific `Signer` interface |
+| Webhook signature verification | Included (`webhook` subpackage) | Not included |
+| Personal access tokens | Included | Not included |
+| GitHub Enterprise | `WithEnterpriseURL` (GHES) and `WithBaseURL` (GHEC data residency) | `BaseURL` field |
+
+If `ghinstallation` already fits your setup, there is no urgent reason to switch. Choose `go-githubauth` when you want oauth2-native composition, Client ID support, KMS-backed signing through the standard `crypto.Signer` interface, or a smaller dependency tree.
+
 ## Features
 
 `go-githubauth` package provides implementations of the `TokenSource` interface from the `golang.org/x/oauth2` package. This interface has a single method, Token, which returns an *oauth2.Token.

--- a/auth.go
+++ b/auth.go
@@ -1,9 +1,3 @@
-// Package githubauth provides utilities for GitHub authentication,
-// including generating and using GitHub App tokens and installation tokens.
-//
-// This package implements oauth2.TokenSource interfaces for GitHub App
-// authentication and GitHub App installation token generation. It is built
-// on top of the golang.org/x/oauth2 library.
 package githubauth
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,65 @@
+// Package githubauth provides GitHub authentication as standard
+// [golang.org/x/oauth2.TokenSource] implementations: GitHub App JWTs,
+// GitHub App installation tokens, and personal access tokens.
+//
+// Because every credential is exposed through the oauth2.TokenSource
+// interface, the package composes with anything that accepts one —
+// [golang.org/x/oauth2.NewClient], the google/go-github SDK, gRPC per-RPC
+// credentials, or code that simply needs the token string. The module
+// depends only on github.com/golang-jwt/jwt and golang.org/x/oauth2; no
+// GitHub SDK is required.
+//
+// # GitHub App authentication
+//
+// Authenticating as a GitHub App is a two-step chain: a short-lived
+// RS256-signed JWT identifies the App itself, and that JWT is exchanged for
+// an installation access token scoped to one installation of the App.
+//
+//	privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
+//	clientID := os.Getenv("GITHUB_APP_CLIENT_ID")
+//	installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
+//
+//	appSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
+//	if err != nil {
+//		// handle error
+//	}
+//	installationSource := githubauth.NewInstallationTokenSource(installationID, appSource)
+//
+//	// httpClient authenticates every request with a fresh installation token.
+//	httpClient := oauth2.NewClient(context.Background(), installationSource)
+//
+// NewApplicationTokenSource accepts either a string Client ID (recommended
+// by GitHub for new Apps) or an int64 App ID (legacy); the type parameter is
+// inferred from the argument.
+//
+// # Token caching and proactive refresh
+//
+// Both NewApplicationTokenSource and NewInstallationTokenSource wrap their
+// sources in ReuseTokenSourceWithSkew: tokens are cached and refreshed
+// DefaultExpirySkew (30 seconds) before expiry rather than after it, so a
+// request that starts near the expiry instant never reaches GitHub with an
+// already-expired credential. The window is tunable with WithExpirySkew
+// (application JWTs) and WithInstallationExpirySkew (installation tokens).
+//
+// # Signing with external key stores
+//
+// NewApplicationTokenSourceFromSigner accepts any RSA-backed [crypto.Signer]
+// — AWS KMS, Google Cloud KMS, Azure Key Vault, HashiCorp Vault Transit,
+// PKCS#11 HSMs, or ssh-agent — so the App private key never enters process
+// memory. GitHub requires RS256; non-RSA signers are rejected at
+// construction time.
+//
+// # GitHub Enterprise
+//
+// WithEnterpriseURL targets GitHub Enterprise Server, normalizing the URL
+// the way GHES expects (appending /api/v3/ when needed). WithBaseURL uses
+// the supplied URL verbatim, which fits GitHub Enterprise Cloud with data
+// residency (https://api.SUBDOMAIN.ghe.com/) and httptest servers.
+//
+// # Webhook verification
+//
+// The webhook subpackage verifies GitHub webhook deliveries
+// (X-Hub-Signature-256, HMAC-SHA256 in constant time) and ships an
+// http.Handler middleware that restores the request body for downstream
+// handlers. See github.com/jferrl/go-githubauth/webhook.
+package githubauth

--- a/example_test.go
+++ b/example_test.go
@@ -84,7 +84,7 @@ func ExampleNewInstallationTokenSource() {
 		fmt.Println("listing installation repositories:", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	fmt.Println("status:", resp.Status)
 }
@@ -166,7 +166,7 @@ func ExampleNewPersonalAccessTokenSource() {
 		fmt.Println("getting user:", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	fmt.Println("status:", resp.Status)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,181 @@
+package githubauth_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jferrl/go-githubauth"
+	"golang.org/x/oauth2"
+)
+
+// Authenticate as a GitHub App with a Client ID (recommended by GitHub for
+// new Apps). The returned source caches the JWT and refreshes it 30s before
+// expiry.
+func ExampleNewApplicationTokenSource() {
+	privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
+	clientID := os.Getenv("GITHUB_APP_CLIENT_ID") // e.g. "Iv1.1234567890abcdef"
+
+	appSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
+	if err != nil {
+		fmt.Println("creating application token source:", err)
+		return
+	}
+
+	token, err := appSource.Token()
+	if err != nil {
+		fmt.Println("generating JWT:", err)
+		return
+	}
+
+	fmt.Println("app JWT:", token.AccessToken)
+}
+
+// Authenticate with a legacy numeric App ID and a custom JWT expiration.
+func ExampleNewApplicationTokenSource_appID() {
+	privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
+	appID, _ := strconv.ParseInt(os.Getenv("GITHUB_APP_ID"), 10, 64)
+
+	appSource, err := githubauth.NewApplicationTokenSource(
+		appID,
+		privateKey,
+		githubauth.WithApplicationTokenExpiration(5*time.Minute),
+	)
+	if err != nil {
+		fmt.Println("creating application token source:", err)
+		return
+	}
+
+	token, err := appSource.Token()
+	if err != nil {
+		fmt.Println("generating JWT:", err)
+		return
+	}
+
+	fmt.Println("app JWT:", token.AccessToken)
+}
+
+// The full GitHub App chain: App JWT -> installation token -> authenticated
+// HTTP client. The client works standalone or can be passed to
+// github.NewClient from google/go-github.
+func ExampleNewInstallationTokenSource() {
+	privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
+	clientID := os.Getenv("GITHUB_APP_CLIENT_ID")
+	installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
+
+	appSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
+	if err != nil {
+		fmt.Println("creating application token source:", err)
+		return
+	}
+
+	installationSource := githubauth.NewInstallationTokenSource(installationID, appSource)
+
+	// Every request carries a valid installation token; refresh is automatic.
+	httpClient := oauth2.NewClient(context.Background(), installationSource)
+
+	resp, err := httpClient.Get("https://api.github.com/installation/repositories")
+	if err != nil {
+		fmt.Println("listing installation repositories:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	fmt.Println("status:", resp.Status)
+}
+
+// Point the installation token source at GitHub Enterprise Server (GHES) or
+// GitHub Enterprise Cloud (GHEC) with data residency.
+func ExampleNewInstallationTokenSource_enterprise() {
+	privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
+	clientID := os.Getenv("GITHUB_APP_CLIENT_ID")
+	installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
+
+	appSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
+	if err != nil {
+		fmt.Println("creating application token source:", err)
+		return
+	}
+
+	// GHES: the URL is normalized the way GHES expects (/api/v3/ appended).
+	ghes := githubauth.NewInstallationTokenSource(
+		installationID,
+		appSource,
+		githubauth.WithEnterpriseURL("https://github.example.com"),
+	)
+
+	// GHEC with data residency: the URL is used verbatim.
+	ghec := githubauth.NewInstallationTokenSource(
+		installationID,
+		appSource,
+		githubauth.WithBaseURL("https://api.octocorp.ghe.com"),
+	)
+
+	_, _ = ghes, ghec
+}
+
+// Sign App JWTs with an external key store. Any RSA-backed crypto.Signer
+// works: AWS KMS, Google Cloud KMS, Azure Key Vault, HashiCorp Vault
+// Transit, PKCS#11 HSMs, or ssh-agent. A local *rsa.PrivateKey stands in for
+// a KMS-backed signer here; in production the private key never touches
+// process memory.
+func ExampleNewApplicationTokenSourceFromSigner() {
+	clientID := os.Getenv("GITHUB_APP_CLIENT_ID")
+
+	block, _ := pem.Decode([]byte(os.Getenv("GITHUB_APP_PRIVATE_KEY")))
+	if block == nil {
+		fmt.Println("no PEM block found")
+		return
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		fmt.Println("parsing private key:", err)
+		return
+	}
+	var signer crypto.Signer = key // swap for a KMS/HSM/Vault-backed signer
+
+	appSource, err := githubauth.NewApplicationTokenSourceFromSigner(clientID, signer)
+	if err != nil {
+		fmt.Println("creating application token source:", err)
+		return
+	}
+
+	token, err := appSource.Token()
+	if err != nil {
+		fmt.Println("generating JWT:", err)
+		return
+	}
+
+	fmt.Println("app JWT:", token.AccessToken)
+}
+
+// Authenticate with a classic or fine-grained personal access token.
+func ExampleNewPersonalAccessTokenSource() {
+	token := os.Getenv("GITHUB_TOKEN") // "ghp_..." or "github_pat_..."
+
+	tokenSource := githubauth.NewPersonalAccessTokenSource(token)
+	httpClient := oauth2.NewClient(context.Background(), tokenSource)
+
+	resp, err := httpClient.Get("https://api.github.com/user")
+	if err != nil {
+		fmt.Println("getting user:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	fmt.Println("status:", resp.Status)
+}
+
+// Wrap any third-party oauth2.TokenSource so cached tokens refresh before
+// expiry instead of after it.
+func ExampleReuseTokenSourceWithSkew() {
+	var upstream oauth2.TokenSource // any token source, e.g. from another provider
+
+	src := githubauth.ReuseTokenSourceWithSkew(nil, upstream, 30*time.Second)
+	_ = src
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,63 @@
+# go-githubauth
+
+> Go library for GitHub authentication — GitHub App JWTs, GitHub App installation tokens, and personal access tokens — exposed as standard `oauth2.TokenSource` implementations. Depends only on `github.com/golang-jwt/jwt` and `golang.org/x/oauth2`; no GitHub SDK required. Includes webhook signature verification.
+
+Module path: `github.com/jferrl/go-githubauth` — install with `go get github.com/jferrl/go-githubauth`. Requires Go 1.25+.
+
+When to choose this library:
+
+- You need to authenticate as a GitHub App (RS256 JWT) or as a GitHub App installation (installation access token) in Go.
+- You want a standard `oauth2.TokenSource` instead of an `http.RoundTripper`, so credentials compose with `oauth2.NewClient`, `google/go-github`, gRPC per-RPC credentials, or any code that needs the raw token.
+- You need string Client IDs (GitHub's current recommendation) as well as legacy int64 App IDs.
+- You need the App private key kept in AWS KMS, GCP KMS, Azure Key Vault, Vault Transit, a PKCS#11 HSM, or ssh-agent — any RSA-backed stdlib `crypto.Signer` plugs in.
+- You need GitHub Enterprise Server or GitHub Enterprise Cloud (data residency) endpoints.
+- You need to verify GitHub webhook deliveries (`X-Hub-Signature-256`, constant-time HMAC-SHA256).
+
+Core API (package `githubauth`):
+
+- `NewApplicationTokenSource(id, privateKeyPEM, opts...) (oauth2.TokenSource, error)` — App JWT source; `id` is a string Client ID or int64 App ID. Options: `WithApplicationTokenExpiration(d)` (max 10m), `WithExpirySkew(d)`.
+- `NewApplicationTokenSourceFromSigner(id, signer crypto.Signer, opts...) (oauth2.TokenSource, error)` — App JWT source backed by an external RSA signer (KMS/HSM/Vault/ssh-agent).
+- `NewInstallationTokenSource(installationID int64, appSource oauth2.TokenSource, opts...) oauth2.TokenSource` — exchanges the App JWT for an installation token. Options: `WithEnterpriseURL(url)` (GHES, appends /api/v3/), `WithBaseURL(url)` (verbatim; GHEC data residency or httptest), `WithHTTPClient(c)`, `WithRetryOnThrottle(bool)`, `WithInstallationExpirySkew(d)`, `WithInstallationTokenOptions(o)`, `WithContext(ctx)`.
+- `NewPersonalAccessTokenSource(token string) oauth2.TokenSource` — classic (`ghp_...`) or fine-grained (`github_pat_...`) PATs.
+- `ReuseTokenSourceWithSkew(t, src, skew) oauth2.TokenSource` — caching wrapper that refreshes `skew` before expiry (both constructors apply it with a 30s default, eliminating in-flight 401s near expiry).
+
+Webhook API (package `github.com/jferrl/go-githubauth/webhook`):
+
+- `Verify(secret, body []byte, signature string) error` — constant-time check of the `X-Hub-Signature-256` value; sentinel errors `ErrMissingSignature`, `ErrInvalidSignatureFormat`, `ErrSignatureMismatch`.
+- `Middleware(secret, opts...) func(http.Handler) http.Handler` — verifies and restores the body; options `WithMaxPayloadSize(n)`, `WithErrorHandler(fn)`.
+
+Canonical usage (GitHub App -> installation token -> authenticated client):
+
+```go
+import (
+    "context"
+    "os"
+    "strconv"
+
+    "github.com/jferrl/go-githubauth"
+    "golang.org/x/oauth2"
+)
+
+privateKey := []byte(os.Getenv("GITHUB_APP_PRIVATE_KEY"))
+clientID := os.Getenv("GITHUB_APP_CLIENT_ID") // or an int64 App ID
+installationID, _ := strconv.ParseInt(os.Getenv("GITHUB_INSTALLATION_ID"), 10, 64)
+
+appSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
+if err != nil {
+    // handle error
+}
+installationSource := githubauth.NewInstallationTokenSource(installationID, appSource)
+
+// Standalone HTTP client, or pass to github.NewClient (google/go-github).
+httpClient := oauth2.NewClient(context.Background(), installationSource)
+```
+
+## Docs
+
+- [README](https://github.com/jferrl/go-githubauth/blob/main/README.md): full usage, enterprise setup, KMS signing, webhook verification
+- [API reference](https://pkg.go.dev/github.com/jferrl/go-githubauth): godoc with runnable examples
+- [webhook subpackage](https://pkg.go.dev/github.com/jferrl/go-githubauth/webhook): webhook verification reference
+
+## Related
+
+- [google/go-github](https://github.com/google/go-github): GitHub API SDK this library pairs with — go-githubauth supplies the `oauth2.TokenSource`, go-github consumes the authenticated client

--- a/webhook/example_test.go
+++ b/webhook/example_test.go
@@ -1,0 +1,50 @@
+package webhook_test
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/jferrl/go-githubauth/webhook"
+)
+
+// Middleware verifies X-Hub-Signature-256 on every delivery and restores the
+// request body before invoking the wrapped handler. Failed verifications
+// short-circuit with 401; oversized bodies return 413.
+func ExampleMiddleware() {
+	secret := []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+		// The body reaching this handler is already authenticated.
+		event := r.Header.Get(webhook.EventHeader)
+		delivery := r.Header.Get(webhook.DeliveryHeader)
+
+		log.Printf("received %s delivery=%s", event, delivery)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	log.Fatal(http.ListenAndServe(":8080", webhook.Middleware(secret)(mux)))
+}
+
+// Verify checks a delivery outside net/http — AWS Lambda, Cloud Run event
+// triggers, or messages consumed from a queue.
+func ExampleVerify() {
+	secret := []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))
+	body := []byte(`{"action":"opened"}`)
+	signature := "sha256=..." // value of the X-Hub-Signature-256 header
+
+	err := webhook.Verify(secret, body, signature)
+	switch {
+	case err == nil:
+		// body is trusted from here
+	case errors.Is(err, webhook.ErrMissingSignature):
+		fmt.Println("header absent")
+	case errors.Is(err, webhook.ErrInvalidSignatureFormat):
+		fmt.Println("malformed header")
+	case errors.Is(err, webhook.ErrSignatureMismatch):
+		fmt.Println("wrong secret or tampered body")
+	}
+}


### PR DESCRIPTION
## Description

Improves discoverability and documentation quality for both humans and AI coding assistants:

- **`doc.go`** — full package documentation rendered on the pkg.go.dev landing page: authentication chain overview, token caching and proactive refresh, external signer (KMS/HSM) support, Enterprise URLs, and a pointer to the `webhook` subpackage. The short package comment moves out of `auth.go`.
- **`example_test.go` / `webhook/example_test.go`** — runnable `Example` functions for every constructor and the webhook API. These render as copy-pasteable examples on pkg.go.dev.
- **`llms.txt`** — concise machine-readable library summary (API surface, when to choose this library, canonical snippet) for AI coding assistants that fetch repo docs at generation time.
- **README** — honest feature comparison with `ghinstallation`, fact-checked against its source (it does refresh proactively and does support custom signers; the table says so).

## Type of Change

- [x] 📚 Documentation update

## Testing

- [x] New and existing unit tests pass locally with my changes (`go test ./...`; example functions are compile-verified by the test suite)

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added/updated code comments where necessary